### PR TITLE
Support Apache httpd 2.3+ configuration syntax

### DIFF
--- a/etc/ocsinventory/ocsinventory-reports.conf
+++ b/etc/ocsinventory/ocsinventory-reports.conf
@@ -24,8 +24,13 @@ Alias OCSREPORTS_ALIAS PATH_TO_OCSREPORTS_DIR
 
 <Directory PATH_TO_OCSREPORTS_DIR>
     # By default, users can use console from everywhere
+    <IfVersion >= 2.3>
+    Require all granted
+    </IfVersion>
+    <IfVersion < 2.3>
     Order deny,allow
     Allow from all
+    </IfVersion>
     Options Indexes FollowSymLinks
     DirectoryIndex index.php
     AllowOverride Options

--- a/etc/ocsinventory/ocsinventory-server.conf
+++ b/etc/ocsinventory/ocsinventory-server.conf
@@ -289,13 +289,18 @@
   # "Virtual" directory for handling OCS Inventory NG agents communications
   # Be careful, do not create such directory into your web server root document !
   <Location /ocsinventory>
+	<IfVersion >= 2.3>
+	Require all granted
+	</IfVersion>
+	<IfVersion < 2.3>
 	order deny,allow
 	allow from all
+	</IfVersion>
 	# If you protect this area you have to deal with http_auth_* agent's parameters
 	# AuthType Basic
 	# AuthName "OCS Inventory agent area"
 	# AuthUserFile "APACHE_AUTH_USER_FILE"
-	# require valid-user
+	# Require valid-user
         SetHandler perl-script
         PerlHandler Apache::Ocsinventory
   </Location>
@@ -308,13 +313,20 @@
         PerlHandler "Apache::Ocsinventory::SOAP"
         
         # By default, you can query web service from everywhere with a valid user
+	<IfVersion >= 2.3>
         Order deny,allow
         Allow from all
+	</IfVersion>
        	AuthType Basic
 	AuthName "OCS Inventory SOAP Area"
 	# Use htpasswd to create/update soap-user (or another granted user)
 	AuthUserFile "APACHE_AUTH_USER_FILE"
+	<IfVersion >= 2.3>
+	Require user "SOAP_USER"
+	</IfVersion>
+        <IfVersion < 2.3>
 	require "SOAP_USER"
+	</IfVersion>
   </location>
 </IfModule>
 


### PR DESCRIPTION
Apache 2.4 has been the stable version for a few years now. This patch adds support for the new syntax of configuration file, with no need to have mod_access_compat enabled.
Using <IfVersion>, old versions of httpd are still supported.