### PR TITLE
Allow httpd to access some pathes in /var/lib

### DIFF
--- a/etc/ocsinventory/ocsinventory-reports.conf
+++ b/etc/ocsinventory/ocsinventory-reports.conf
@@ -70,6 +70,16 @@ Alias OCSREPORTS_ALIAS PATH_TO_OCSREPORTS_DIR
 # 
 # Alias to put Deployment package files outside Apache document root directory
 #
+<Directory PATH_TO_PACKAGES_DIR>
+   <IfModule mod_authz_core.c>
+     # Apache 2.4
+     Require all granted
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+     Order deny,allow
+     Allow from all
+   </IfModule>
+</Directory>
 Alias PACKAGES_ALIAS PATH_TO_PACKAGES_DIR
 
 
@@ -78,4 +88,14 @@ Alias PACKAGES_ALIAS PATH_TO_PACKAGES_DIR
 #
 # Alias to put Snmp custom Mibs files outside Apache document root directory
 #
+<Directory PATH_TO_SNMP_DIR>
+   <IfModule mod_authz_core.c>
+     # Apache 2.4
+     Require all granted
+   </IfModule>
+   <IfModule !mod_authz_core.c>
+     Order deny,allow
+     Allow from all
+   </IfModule>
+</Directory>
 Alias SNMP_ALIAS PATH_TO_SNMP_DIR


### PR DESCRIPTION
In some distros, Apache 2.4 brings new restrictions to which directories are
allowed. For example, in Debian, only /usr/share and /var/www are allowed.

We need to explicitly grant access to PATH_TO_PACKAGES_DIR and
PATH_TO_SNMP_DIR, which typically maps somewhere inside
/var/lib/ocsinventory-reports/.