### PR TITLE
[Bug fix] remove invalid characters in the invalid xml

### DIFF
--- a/Apache/Ocsinventory.pm
+++ b/Apache/Ocsinventory.pm
@@ -200,10 +200,19 @@ sub handler{
     # Parse the XML request
     # Retrieving xml parsing options if needed
     &_get_xml_parser_opt( \%XML_PARSER_OPT ) unless %XML_PARSER_OPT;
-    unless($query = XML::Simple::XMLin( $inflated, %XML_PARSER_OPT )){
-      &_log(507,'handler','Xml stage');
-      return &_end(APACHE_BAD_REQUEST);
-    }
+    eval {
+      unless($query = XML::Simple::XMLin( $inflated, %XML_PARSER_OPT )){
+        &_log(507,'handler','Xml stage');
+        return &_end(APACHE_BAD_REQUEST);
+      }
+    } or do {
+    # filter the invalid characters in a xml file
+      $inflated =~ s/[\x00-\x08\x0B-\x1F\x7F-\xFF]//g;
+      unless($query = XML::Simple::XMLin( $inflated, %XML_PARSER_OPT )){
+        &_log(507,'handler','Xml stage');
+        return &_end(APACHE_BAD_REQUEST);
+      }
+    };
     $CURRENT_CONTEXT{'XML_ENTRY'} = $query;
 
     # Get the request type


### PR DESCRIPTION
Hello,

Bug: If an user sets the description of windows machine to contain invalid characters, when agent send that information to the server, the server cannot handle this case because it cannot parse the data.

For example: those following characters prevent the server from updating the status of the machine : 

￧qﾨ￡ﾧF FWﾄ￦Aￗ ￹ﾩﾀLh )￁pNﾟﾹ=Aﾖ￧ ￑&lt;?﾿:￘T￾￪MNﾑ�pﾝￋ￥￲

Importance: 3/5 because of the security issue, someone can prevent the update by setting the invalid character in parameters from one machine

Patch: in case of faillure of parsing the xml data, the server will remove all the invalid character presenting in the file and parse the xml data again.

Truc
