### PR TITLE
Add hash management to prevent crash on incorrect inventory ata

### DIFF
--- a/Apache/Ocsinventory/Server/Inventory/Data.pm
+++ b/Apache/Ocsinventory/Server/Inventory/Data.pm
@@ -69,27 +69,29 @@ sub _init_map{
      
     # Parse fields of the current section
     for $field ( keys(%{$DATA_MAP{$section}->{fields}} ) ){
-      if(!$DATA_MAP{$section}->{fields}->{$field}->{noSql}){
-        push @{$sectionsMeta->{$section}->{field_arrayref}}, $field;
-        $sectionsMeta->{$section}->{noSql} = 1 unless $sectionsMeta->{$section}->{noSql};
-      }
-      if($DATA_MAP{$section}->{fields}->{$field}->{filter}){
-        next unless $ENV{OCS_OPT_INVENTORY_FILTER_ENABLED};
-        push @{$sectionsMeta->{$section}->{field_filtered}}, $field;
-        $sectionsMeta->{$section}->{filter} = 1 unless $sectionsMeta->{$section}->{filter};
-      }
-      if($DATA_MAP{$section}->{fields}->{$field}->{cache}){
-        next unless $ENV{OCS_OPT_INVENTORY_CACHE_ENABLED};
-        $sectionsMeta->{$section}->{field_cached}->{$field} = $field_index;
-        $sectionsMeta->{$section}->{cache} = 1 unless $sectionsMeta->{$section}->{cache};
-      }
-      if(defined $DATA_MAP{$section}->{fields}->{$field}->{fallback}){
-        $sectionsMeta->{$section}->{fields}->{$field}->{fallback} = $DATA_MAP{$section}->{fields}->{$field}->{fallback};
-      }
+      if(ref($refXml) eq 'HASH'){
+        if(!$DATA_MAP{$section}->{fields}->{$field}->{noSql}){
+          push @{$sectionsMeta->{$section}->{field_arrayref}}, $field;
+          $sectionsMeta->{$section}->{noSql} = 1 unless $sectionsMeta->{$section}->{noSql};
+        }
+        if($DATA_MAP{$section}->{fields}->{$field}->{filter}){
+          next unless $ENV{OCS_OPT_INVENTORY_FILTER_ENABLED};
+          push @{$sectionsMeta->{$section}->{field_filtered}}, $field;
+          $sectionsMeta->{$section}->{filter} = 1 unless $sectionsMeta->{$section}->{filter};
+        }
+        if($DATA_MAP{$section}->{fields}->{$field}->{cache}){
+          next unless $ENV{OCS_OPT_INVENTORY_CACHE_ENABLED};
+          $sectionsMeta->{$section}->{field_cached}->{$field} = $field_index;
+          $sectionsMeta->{$section}->{cache} = 1 unless $sectionsMeta->{$section}->{cache};
+        }
+        if(defined $DATA_MAP{$section}->{fields}->{$field}->{fallback}){
+          $sectionsMeta->{$section}->{fields}->{$field}->{fallback} = $DATA_MAP{$section}->{fields}->{$field}->{fallback};
+        }
 
-      if(defined $DATA_MAP{$section}->{fields}->{$field}->{type}){
-        $sectionsMeta->{$section}->{fields}->{$field}->{type} = $DATA_MAP{$section}->{fields}->{$field}->{type};
-      }     
+        if(defined $DATA_MAP{$section}->{fields}->{$field}->{type}){
+          $sectionsMeta->{$section}->{fields}->{$field}->{type} = $DATA_MAP{$section}->{fields}->{$field}->{type};
+        }  
+      }   
  
       $field_index++;      
     }


### PR DESCRIPTION
In some cases the inventory process crash if sended data are malformed. ( not HASH )

It can happen on specific device who can't retrieve somes specific data or if the output returned by the system is not readable by the agent

Inventory tests has been done on : 
- Win 7
- Win 8 / 8.1
- Win 10
- Ubuntu 16.04
- Fedora 22
- Centos 7
- Opensuse 42
- Dockers containers

If the agent don't retrieve a well formed data the section is just skipped by the server and prevent the crash.

Regards,
Gilles Dubois.