### PR TITLE
Update Ocsinventory.pm

### DIFF
--- a/Apache/Ocsinventory.pm
+++ b/Apache/Ocsinventory.pm
@@ -212,10 +212,14 @@ sub handler{
     # Parse the XML request
     # Retrieving xml parsing options if needed
     &_get_xml_parser_opt( \%XML_PARSER_OPT ) unless %XML_PARSER_OPT;
-    unless($query = XML::Simple::XMLin( $inflated, %XML_PARSER_OPT )){
-      &_log(507,'handler','Xml stage');
-      return &_end(APACHE_BAD_REQUEST);
-    }
+    eval {
+        $query = XML::Simple::XMLin( $inflated, %XML_PARSER_OPT );
+    } or do {
+        unless($query = XML::Simple::XMLin( encode('utf8',$inflated), %XML_PARSER_OPT )){
+          &_log(507,'handler','Xml stage');
+          return &_end(APACHE_BAD_REQUEST);
+        }
+    };
     $CURRENT_CONTEXT{'XML_ENTRY'} = $query;
 
     # Get the request type


### PR DESCRIPTION
This part of code will terminate if incoming xml having non utf-8 encoding, 
Enhanced code on upon eval of such error, xml to be encoded utf-8.

This will be better solution than removing the non utf-8 characters.

[Bug fix] remove invalid characters in the invalid xml
https://github.com/OCSInventory-NG/OCSInventory-Server/pull/8