### PR TITLE
Fix typo error that breaks OCSInventory-Docker-Image install with 2.4…

### DIFF
--- a/binutils/docker-download.sh
+++ b/binutils/docker-download.sh
@@ -8,7 +8,7 @@ ReleaseBaseUrl="https://github.com/OCSInventory-NG/OCSInventory-ocsreports/relea
 # Last release tag
 LastReleaseTag="${VERSION}/"
 # Archive name
-LastReleaseArchive="OCSNG_UNIX_SERVER-${VERSION}"
+LastReleaseArchive="OCSNG_UNIX_SERVER_${VERSION}"
 # Archive extension
 ArchiveExtension=".tar.gz"
 # File destination


### PR DESCRIPTION
… release.

## Description
This is a first pull request for OCSInventory-Server component. 

## Related Issues
2.4 release is out since a few days. Docker image is not updated (remains in 2.3.1.). I made minor fixes to allow download of 2.4 release with the existing docker-download.sh binary util. 
The URL called through wget was not correct, maybe a typo mistake ? I swapped a "-" for a "_". I also updated "OCSInventory-NG/OCSInventory-Docker-Image" with 2.4 references in order to allow proper download of the new release.

## Test environment
Tests has been made on macOS 10.12 client with Docker-ce 17.12 and CentOS 7.3 with Docker-ce 17.12

#### General informations
Operating system : macOS + GNU/Linux CentOS.


## Deploy Notes
In order to work, it has to be completed by another pull I made on OCSInventory-Docker-Image project.

## Impacted Areas in Application
Main components of the OCSInventory-NG project.
