### PR TITLE
Display error when MySQL connection fails

### DIFF
--- a/Apache/Ocsinventory/Interface/Database.pm
+++ b/Apache/Ocsinventory/Interface/Database.pm
@@ -71,6 +71,9 @@ sub database_connect{
 
   # Connection...
   my $dbh = DBI->connect( "DBI:mysql:database=$dbName;host=$dbHost;port=$dbPort", $dbUser, $dbPwd, \%params);
+  unless($dbh) {
+    die DBI->errstr;
+  }
   $dbh->do("SET NAMES 'utf8'") if($dbh && $ENV{'OCS_OPT_UNICODE_SUPPORT'});
   $dbh->do("SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
   return $dbh;  

--- a/Apache/Ocsinventory/Server/System.pm
+++ b/Apache/Ocsinventory/Server/System.pm
@@ -185,6 +185,10 @@ sub _database_connect{
 
   # Connection...
   my $dbh = DBI->connect("DBI:mysql:database=$database;host=$host;port=$port", $user, $password, \%params);
+  unless($dbh) {
+    &_log(521, 'database_connect', DBI->errstr);
+    return undef;
+  }
   $dbh->do("SET NAMES 'utf8'") if($dbh && $ENV{'OCS_OPT_UNICODE_SUPPORT'});
   $dbh->do("SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION'");
   return $dbh;


### PR DESCRIPTION
## Description
Simply display MySQL errors during connection. Else, server fails with something like:
```
Can't call method "do" on an undefined value at /usr/share/perl5/Apache/Ocsinventory/Server/System.pm line 189
```

#### General informations
Operating system : Debian testing

#### Server informations
Perl version : 5.26.2
Mysql / Mariadb / Percona version :  any

## Impacted Areas in Application
List general components of the application that this PR will affect:

* OCS reports (improvement)
