### PR TITLE
Fix to issue 130 (CVE-2018-14473)

### DIFF
--- a/Apache/Ocsinventory/Server/System.pm
+++ b/Apache/Ocsinventory/Server/System.pm
@@ -375,6 +375,7 @@ sub _modules_search{
 
 sub _get_xml_parser_opt{
   my $hash_ref = shift; 
+  $hash_ref->{'ParserOpts'} = [ NoLWP => 1 ]; # Prevent XXE (see CVE-2018-14473)
   $hash_ref->{'SuppressEmpty'} = 1;
   $hash_ref->{'ForceArray'} = [];
   @{$hash_ref->{'ForceArray'}} = &_get_xml_parser_opt_force_array();


### PR DESCRIPTION
The followinf PR fixes CVE-2018-144473.

I think it's a good solution as external DTD's don't seem to be needed within ocsinventory-server.

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
Fix to issue 130 (CVE-2018-14473)

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-Server/issues/130

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :

#### Server informations
Perl version :
Mysql / Mariadb / Percona version :  


## Deploy Notes
None

## Impacted Areas in Application
ocsinventory-server

*
