### PR TITLE
Fix Ipdiscover.pm Not a HASH reference

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
@@ -70,7 +70,9 @@ sub _ipdiscover_prolog_resp{
   my $resp = shift;
   
   my ($ua, $os, $v);
- 
+
+  return unless (ref $current_context->{'PARAMS'}{'IPDISCOVER'} eq ref {}); # Not a HASH reference
+
   my $lanToDiscover = $current_context->{'PARAMS'}{'IPDISCOVER'}->{'TVALUE'};
   my $behaviour     = $current_context->{'PARAMS'}{'IPDISCOVER'}->{'IVALUE'};
   my $groupsParams  = $current_context->{'PARAMS_G'};


### PR DESCRIPTION
## Status
**READY**

## Description
Fix `Not a HASH reference at Ipdiscover.pm line 74` 
that happens when receiving inventory of a computer that has (but shouldn't) multiple elected ipdiscover networks.

## Related Issues
Fix #138
Related https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/254

## Impacted Areas in Application
* inventory prolog
* ipdiscover
