### PR TITLE
feature prolog max sessions per min

### DIFF
--- a/etc/ocsinventory/ocsinventory-server.conf
+++ b/etc/ocsinventory/ocsinventory-server.conf
@@ -220,6 +220,10 @@
   # Accept an inventory only if required by server
   #( Refuse "forced" inventory)
   PerlSetEnv OCS_OPT_INVENTORY_SESSION_ONLY 0
+  # Number of sessions to Decline prolog when max sessions per time is reached
+  #PerlSetEnv OCS_OPT_MAX_SESSIONS_PER_TIME 300
+  # Number of seconds to Decline prolog when max sessions per time is reached
+  #PerlSetEnv OCS_OPT_MAX_SESSIONS_TIME 60
 
 # ===== TAG =====
 


### PR DESCRIPTION
## Status
**READY**

## Description
Add option to decline prolog when max sessions per time is reached.
This helps busy servers receiving too many simultaneous inventory.

It add 2 config options for max sessions per time:
* Number of sessions: `OCS_OPT_MAX_SESSIONS_PER_TIME`
* Number of seconds: `OCS_OPT_MAX_SESSIONS_TIME`

When the number of started sessions reach `MAX_SESSIONS_PER_TIME` in `MAX_SESSIONS_TIME` seconds the server reply prolog declined.

This way we can control server load by delaying receive of inventory when the server is processing many of them.

## Impacted Areas in Application
* prolog
