### PR TITLE
Defined IPDISCOVER_BETTER_THRESHOLD as an IVALUE

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
@@ -361,7 +361,7 @@ sub _ipdiscover_evaluate{
             return 1;
           }
           $dbh->commit;
-          &_log(1001,'ipdiscover',($over?'over':'better')."($_->{IPSUBNET})") if $ENV{'OCS_OPT_LOGLEVEL'};
+           &_log(1001,'ipdiscover',($over?'over':'better')."($_->{IPSUBNET})"."(OLD=($worth[0],$worth[1]),NEW=($DeviceID,$quality))(THRESHOLD=$ENV{'OCS_OPT_IPDISCOVER_BETTER_THRESHOLD'})") if $ENV{'OCS_OPT_LOGLEVEL'};
           return 0;
         }
       }

--- a/Apache/Ocsinventory/Server/System/Config.pm
+++ b/Apache/Ocsinventory/Server/System/Config.pm
@@ -268,7 +268,7 @@ our %CONFIG = (
     filter => qr '^([1-9]\d*)$'
   },
   IPDISCOVER_BETTER_THRESHOLD => {
-    type => 'TVALUE',
+    type => 'IVALUE',
     default => 1,
     unit => 'day',
     description => 'Specify the minimal difference to replace an ipdiscover agent',


### PR DESCRIPTION
Defined IPDISCOVER_BETTER_THRESHOLD as an IVALUE in Config.pm, as it is defined in the db (see file ocsbase.sql in OCSInventory-ocsreports)

This fixes issue 154 (https://github.com/OCSInventory-NG/OCSInventory-Server/issues/154)

## Status
**READY**

## Description
See https://github.com/OCSInventory-NG/OCSInventory-Server/issues/154

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-Server/issues/154

## Todos
Validate that IPDISCOVER_BETTER_THRESHOLD must indeed be defined as an IVALUE and not the other way around (ie: that ocsbase.sql should be updated to make it a TVALUE)

## Test environment
Not tested yet; I've just modified the Config.pm file of my production server.


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1. If IPDISCOVER_BETTER_THRESHOLD  must in fact be a TVALUE then a db migration should be foreseen (and this PR canceled)

## Impacted Areas in Application
IPDISCOVER
