### PR TITLE
force unescape json format in json rendering and correct NetworkID pa…

### DIFF
--- a/Api/Ocsinventory/Restapi/Loader.pm
+++ b/Api/Ocsinventory/Restapi/Loader.pm
@@ -31,20 +31,20 @@ require Api::Ocsinventory::Restapi::Snmp::Get::SnmpListId; # Get list of Snmp ID
 
 get '/v1/computers/listID' => sub {
         my $c = shift;
-        render_responce($c, Api::Ocsinventory::Restapi::Computer::Get::ComputersListId::get_computers_id());
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Computer::Get::ComputersListId::get_computers_id());
 };
 
 get '/v1/computer/:id' => sub {
         my $c = shift;
         my $id = $c->stash('id');
-        render_responce($c, Api::Ocsinventory::Restapi::Computer::Get::ComputerId::get_computer($id));
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Computer::Get::ComputerId::get_computer($id));
 };
 
 get '/v1/computer/:id/:field' => sub {
         my $c = shift;
         my $id = $c->stash('id');
         my $field = $c->stash('field');
-        render_responce($c, Api::Ocsinventory::Restapi::Computer::Get::ComputerIdField::get_computer_field($id, $field));
+        $c->render(text => Api::Ocsinventory::Restapi::Computer::Get::ComputerIdField::get_computer_field($id, $field));
 };
 
 get '/v1/computers' => sub {
@@ -54,7 +54,7 @@ get '/v1/computers' => sub {
         my $start = $c->param('start')||0;
         my $limit = $c->param('limit')||0;
 
-        render_responce($c, Api::Ocsinventory::Restapi::Computer::Get::Computers::get_computers($limit, $start));
+        $c->render(format => 'json', text => Api::Ocsinventory::Restapi::Computer::Get::Computers::get_computers($limit, $start));
 };
 
 get '/v1/computers/search' => sub {
@@ -62,7 +62,7 @@ get '/v1/computers/search' => sub {
 
         my $params_hash = $c->req->params->to_hash;
 
-        render_responce($c, Api::Ocsinventory::Restapi::Computer::Get::ComputersSearch::get_computers_search($params_hash));
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Computer::Get::ComputersSearch::get_computers_search($params_hash));
 };
 
 get '/v1/ipdiscover' => sub {
@@ -71,19 +71,23 @@ get '/v1/ipdiscover' => sub {
         my $start = $c->param('start');
         my $limit = $c->param('limit');
 
-        render_responce($c, Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover::get_ipdiscovers($start, $limit));
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover::get_ipdiscovers($start, $limit));
 };
 
 get '/v1/ipdiscover/:network' => sub {
         my $c = shift;
+	# Debuggibg MH : Dump $c Mojo Object in /var/log/apache2/error.log
+#       warn "/v1/ipdiscover/:network : ".Dumper($c)."\n"; 
         my $network = $c->stash('network');
-
-        render_responce($c, Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
+	# QuickFix MH: donit know why a IPv4 10.20.30.40 is split as Mojo attrs: param=>10 format=20.30.40
+	$network .= ".".$c->stash('format');
+	
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
 };
 
 get '/v1/snmps/listID' => sub {
         my $c = shift;
-        render_responce($c, Api::Ocsinventory::Restapi::Snmp::Get::SnmpListId::get_snmps_id());
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Snmp::Get::SnmpListId::get_snmps_id());
 };
 
 get '/v1/snmp' => sub {
@@ -93,33 +97,20 @@ get '/v1/snmp' => sub {
         my $start = $c->param('start')||0;
         my $limit = $c->param('limit')||0;
 
-        render_responce($c, Api::Ocsinventory::Restapi::Snmp::Get::Snmp::get_snmp($limit, $start));
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Snmp::Get::Snmp::get_snmp($limit, $start));
 };
 
 get '/v1/snmp/:id' => sub {
         my $c = shift;
         my $id = $c->stash('id');
-        render_responce($c, Api::Ocsinventory::Restapi::Snmp::Get::SnmpId::get_snmp_id($id));
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Snmp::Get::SnmpId::get_snmp_id($id));
 };
 
 get '/v1/snmp/:id/:field' => sub {
         my $c = shift;
         my $id = $c->stash('id');
         my $field = $c->stash('field');
-        render_responce($c, Api::Ocsinventory::Restapi::Snmp::Get::SnmpIdField::get_snmp_field($id, $field));
-};
-
-## Common render logic
-
-sub render_responce {
-        my ($c, $data) = @_;
-
-        if (defined($c->param('noescape'))) {
-                $c->render(text => $data, format => 'json');
-        } else {
-                $c->render(json => $data);
-        };
-
+        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Snmp::Get::SnmpIdField::get_snmp_field($id, $field));
 };
 
 app->start;


### PR DESCRIPTION
…ram for /v1/ipdiscover/{quadIpv4}

Sorry I should have read : [Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)
before this pull request proposal.
I'm new to gitlab and didn't play for a while with code repositories.
Next time, and I'll send request for issue. 

There was no comments in ocsapi code about the reasons of escaping all double quotes in json reply and putting double quote around the whole json response. So today I removed on my freshly installed ocsAPI all the json_encode in the API Perl modules. And tonight I see that s.o. added a "render_responce()" to permit ?noescape GET selective displaying.
When, or for what platform a quoted json is valid ? So I propose a pure json format http response.

Furthermore Mojolicious::Lite is splitting GET params at the first dot; though http://ocs.local/ocsapi/v1/ipdiscover/10.20.30.40 is returned in Mojo structure as network=10 + format="20.30.40" (thanxx to Data::Dumper). I still haven't foud in Mojo docs, how to change this behaviour. So I propose a loosy corrective with arg1+format concatenation.

regard

MH