### PR TITLE
Fix syntax to access single array values

### DIFF
--- a/Apache/Ocsinventory/Interface/AssetCategory.pm
+++ b/Apache/Ocsinventory/Interface/AssetCategory.pm
@@ -51,7 +51,7 @@ sub set_asset_category{
         my $execution;
 
         for (my $i = 0; $i < scalar @part_query; $i++){
-            if (@args[$i]) {
+            if ($args[$i]) {
                 $query .= $part_query[$i] . $args[$i];
             } else {
                 $query .= $part_query[$i];


### PR DESCRIPTION
Fixes the following warning:
Scalar value @args[$i] better written as $args[$i]
