### PR TITLE
added ssl support for mysql.

### DIFF
--- a/etc/ocsinventory/ocsinventory-server.conf
+++ b/etc/ocsinventory/ocsinventory-server.conf
@@ -29,6 +29,19 @@
   PerlSetEnv OCS_DB_USER ocs
   # Password for user
   PerlSetVar OCS_DB_PWD ocs
+  # SSL Configuration
+  # 0 to disable the SSL support for MySQL/MariaDB
+  # 1 to enable the SSL support for MySQL/MariaDB
+  PerlSetEnv OCS_DB_SSL_ENABLED 0
+  # PerlSetEnv OCS_DB_SSL_CLIENT_KEY /etc/ssl/private/client.key
+  # PerlSetEnv OCS_DB_SSL_CLIENT_CERT /etc/ssl/certs/client.crt
+  # PerlSetEnv OCS_DB_SSL_CA_CERT /etc/ssl/certs/ca.crt
+  # SSL Mode 
+  # - SSL_MODE_PREFERRED (SSL enabled but optional)
+  # - SSL_MODE_REQUIRED (SSL enabled, mandatory but don't verify server certificate. Ex self signed cert)
+  # - SSL_MODE_STRICT (SSL enabled, mandatory and server cert must be trusted)
+  PerlSetEnv OCS_DB_SSL_MODE SSL_MODE_PREFERRED
+  
 
   # Slave Database settings
   # Replace DATABASE_SERVER by hostname or ip of MySQL server for READ
@@ -42,6 +55,18 @@
   # PerlSetEnv OCS_DB_SL_NAME ocsweb
   # Password for user
   # PerlSetVar OCS_DB_SL_PWD ocs
+  # SSL Configuration for Slave database
+  # 0 to disable the SSL support for MySQL/MariaDB
+  # 1 to enable the SSL support for MySQL/MariaDB
+  # PerlSetEnv OCS_DB_SL_SSL_ENABLED 0
+  # PerlSetEnv OCS_DB_SL_SSL_CLIENT_KEY /etc/ssl/private/client.key
+  # PerlSetEnv OCS_DB_SL_SSL_CLIENT_CERT /etc/ssl/certs/client.crt
+  # PerlSetEnv OCS_DB_SL_SSL_CA_CERT /etc/ssl/certs/ca.crt
+  # SSL Mode 
+  # - SSL_MODE_PREFERRED (SSL enabled but optional)
+  # - SSL_MODE_REQUIRED (SSL enabled, mandatory but don't verify server certificate. Ex self signed cert)
+  # - SSL_MODE_STRICT (SSL enabled, mandatory and server cert must be trusted)
+  # PerlSetEnv OCS_DB_SL_SSL_MODE SSL_MODE_PREFERRED
   
   # Path to log directory (must be writeable)
   PerlSetEnv OCS_OPT_LOGPATH "PATH_TO_LOG_DIRECTORY"


### PR DESCRIPTION
Handles ssl mode such as optional, ssl verify or not verify.
Added hability to provide client certificate/key + ca cert

## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
**READY**

## Description
Add ssl support for mysql/mariadb on the communication server for both master and slave database.


## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-Server/issues/117

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :
Debian Stretch 9

#### Server informations
Perl version :
Mariadb 10.3 with ssl

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Communication server might be impacted. Agent might not able to send their changes if the server is not able to write in the database
