### PR TITLE
Delay compression of log files when rotating them.

### DIFF
--- a/etc/logrotate.d/ocsinventory-server
+++ b/etc/logrotate.d/ocsinventory-server
@@ -4,5 +4,6 @@ PATH_TO_LOG_DIRECTORY/*.log {
 	daily
 	rotate 7
 	compress
+	delaycompress
 	missingok
 }


### PR DESCRIPTION
## Status
**READY**

## Description
I'm getting lots of following errors when rotating the logs:

```
/etc/cron.daily/logrotate:
error: Compressing program wrote following message to stderr when compressing log /var/log/ocsinventory-server/activity.log.1:
gzip: stdin: file size changed while zipping
```

I believe adding the `delaycompress` setting to logrotate will fix this with no adverse side effect.

#### General informations
Operating system : Ubuntu

## Impacted Areas in Application
Logging

*
