### PR TITLE
Issue 208

### DIFF
--- a/etc/ocsinventory/ocsinventory-restapi.conf
+++ b/etc/ocsinventory/ocsinventory-restapi.conf
@@ -9,6 +9,11 @@ PerlOptions +Parent
   $ENV{OCS_DB_LOCAL} = 'ocsweb';
   $ENV{OCS_DB_USER} = 'ocs';
   $ENV{OCS_DB_PWD} = 'ocs';
+  $ENV{OCS_DB_SSL_ENABLED} = 0;
+#  $ENV{OCS_DB_SSL_CLIENT_KEY} = '';
+#  $ENV{OCS_DB_SSL_CLIENT_CERT} = '';
+#  $ENV{OCS_DB_SSL_CA_CERT} = '';
+  $ENV{OCS_DB_SSL_MODE} = 'SSL_MODE_PREFERRED';
 </Perl>
 
 <Location /ocsapi>


### PR DESCRIPTION
## Must read before submitting
Please, take a look to our contributing guidelines before submitting your pull request.
There's some simple rules that will help us to speed up the review process and avoid any misunderstanding

[Contributors GuideLines](https://github.com/OCSInventory-NG/OCSInventory-ocsreports/blob/master/.github/Contributing.md)

## Status
READY/

## Description
Add the mysql ssl support for the rest api.
Feature has been previously implemented for communication server and interface.
Rest API was missing.

## Related Issues
https://github.com/OCSInventory-NG/OCSInventory-Server/issues/208

## Todos
- [ ] Tests
- [ ] Documentation

## Test environment
If some tests has been already made, please give us your test environment' specs

#### General informations
Operating system :

#### Server informations
Perl version :
Mysql / Mariadb / Percona version :  


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, logical changes, etc.

1. SSL is disabled by default on rest api

## Impacted Areas in Application
List general components of the application that this PR will affect:

* Rest API
