### PR TITLE
workaround agent old_deviceid bug

### DIFF
--- a/Apache/Ocsinventory/Server/Duplicate.pm
+++ b/Apache/Ocsinventory/Server/Duplicate.pm
@@ -52,6 +52,12 @@ sub _duplicate_main{
   my $dbh = $Apache::Ocsinventory::CURRENT_CONTEXT{'DBI_HANDLE'};
   my $DeviceID = $Apache::Ocsinventory::CURRENT_CONTEXT{'DATABASE_ID'};
 
+  # workaround agent old_deviceid bug
+  if(!$result->{CONTENT}->{OLD_DEVICEID} and $result->{CONTENT}->{DOWNLOAD}->{HISTORY}->{OLD_DEVICEID})
+  {
+    $result->{CONTENT}->{OLD_DEVICEID} = $result->{CONTENT}->{DOWNLOAD}->{HISTORY}->{OLD_DEVICEID};
+  }
+
   # If the duplicate is specified
   if($result->{CONTENT}->{OLD_DEVICEID} and $result->{CONTENT}->{OLD_DEVICEID} ne $Apache::Ocsinventory::CURRENT_CONTEXT{'DEVICEID'}){
     &_log(326,'duplicate',$result->{CONTENT}->{OLD_DEVICEID}) if $ENV{'OCS_OPT_LOGLEVEL'};


### PR DESCRIPTION
## Status
**READY**

## Description
This is a workaround for Windows Agent bug (https://github.com/OCSInventory-NG/WindowsAgent/issues/160) that put xml element `OLD_DEVICEID` inside `DOWNLOAD/HISTORY`.

The windows agent bug cause the communication server to not detect and merge a duplicate when both deviceid and mac address change.

With this patch the communication server also check for OLD_DEVICEID inside DOWNLOAD/HISTORY.

## Related Issues
https://github.com/OCSInventory-NG/WindowsAgent/issues/160
