### PR TITLE
Fix null date on IpDiscover

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
@@ -278,10 +278,10 @@ sub _ipdiscover_read_result{
         my $row_verif = $request_verif->fetchrow_hashref;
 
         if (defined $row_verif->{'TAG'}) {
-          $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NULL, NAME=? WHERE MAC=? AND TAG=?');
+          $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NOW(), NAME=? WHERE MAC=? AND TAG=?');
           $update_req->execute($_->{I}, $mask, $subnet, $_->{N}, $_->{M}, $tag);
         } else {
-          $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NULL, NAME=?, TAG=? WHERE MAC=?');
+          $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NOW(), NAME=?, TAG=? WHERE MAC=?');
           $update_req->execute($_->{I}, $mask, $subnet, $_->{N}, $tag, $_->{M});
         }
         unless($update_req->rows){
@@ -291,7 +291,7 @@ sub _ipdiscover_read_result{
       }
     } else {
       # We insert the results (MAC/IP)
-      $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NULL, NAME=? WHERE MAC=?');
+      $update_req = $dbh->prepare('UPDATE netmap SET IP=?,MASK=?,NETID=?,DATE=NOW(), NAME=? WHERE MAC=?');
       $insert_req = $dbh->prepare('INSERT INTO netmap(IP, MAC, MASK, NETID, NAME) VALUES(?,?,?,?,?)');
 
       for(@$base){


### PR DESCRIPTION
## Status
**READY**

## Description
On certain MySQL versions, IpDiscover date is set to 00-00-0000 00:00:00
The problem is related to the IpDiscover Update method that was setting null as date which translate to 00-00-0000 00:00:00

