### PR TITLE
ipdiscover: check ignored subnet

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
@@ -319,6 +319,13 @@ sub _ipdiscover_read_result{
     return 1;
   }
   
+  # check ignored subnet
+  $request=$dbh->prepare('SELECT SUBNET FROM blacklist_subnet WHERE SUBNET=?');
+  $request->execute($subnet);
+  if($request->rows > 0){
+    return 1;
+  }
+
   return 0;
 }
 
@@ -338,6 +345,13 @@ sub _ipdiscover_find_iface{
         if($_->{IPMASK}=~/^(?:255\.){2}|^0x(?:ff){2}/){
           if($_->{IPSUBNET}=~/^(\d{1,3}(?:\.\d{1,3}){3})$/){
   
+    # check ignored subnet
+    $request = $dbh->prepare('SELECT SUBNET FROM blacklist_subnet WHERE SUBNET=?');
+    $request->execute($_->{IPSUBNET});
+    if($request->rows > 0){
+      next;
+    }
+
     # Looking for a need of ipdiscover
     $request = $dbh->prepare('SELECT HARDWARE_ID FROM devices WHERE TVALUE=? AND NAME="IPDISCOVER"');
     $request->execute($_->{IPSUBNET});


### PR DESCRIPTION
## Status :
**READY**

## Description :
This is a improvement for ipdiscover to skip ipdiscover scan on ignored subnets.

On machine ipdiscover election it checks if the current subnet exists on `blacklist_subnet` table and skip a ipdiscover scan for it.

This is a re-submit of #245 because I deleted old branch to rebase it on master.
