### PR TITLE
Remove old /ocsplugins endpoint

### DIFF
--- a/etc/ocsinventory/ocsinventory-server.conf
+++ b/etc/ocsinventory/ocsinventory-server.conf
@@ -328,22 +328,6 @@
         PerlHandler Apache::Ocsinventory
   </Location>
 
-#Web Service for plugin engine
-  <Location /ocsplugins>
-    <IfModule mod_authz_core.c>
-      # Apache 2.4
-      Require local
-    </IfModule>
-    <IfModule !mod_authz_core.c>
-      # Apache 2.2
-      order deny,allow
-      allow from 127.0.0.1
-    </IfModule>
-    SetHandler perl-script
-    PerlHandler Apache::Ocsinventory::Plugins::Apache
-  </Location>
-
-
   # Web service apache settings
   PerlModule Apache::Ocsinventory::SOAP
 


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system :

## Server informations :
Perl version :
Mysql / Mariadb / Percona version :  

## Status :
**READY/IN DEVELOPMENT/HOLD**

## Description :
A few sentences describing the overall goals of the pull request's commits.
