### PR TITLE
Fix API bugs

### DIFF
--- a/Api/Ocsinventory/Restapi/ApiCommon.pm
+++ b/Api/Ocsinventory/Restapi/ApiCommon.pm
@@ -70,7 +70,7 @@ sub api_database_connect{
     }
 
     # Connection...
-    my $dbh = DBI->connect( "DBI:mysql:database=$dbName;host=$dbHost;port=$dbPort".$sslMode, $dbUser, $dbPwd, {RaiseError => 1}) or die $DBI::errstr;
+    my $dbh = DBI->connect( "DBI:mysql:database=$dbName;host=$dbHost;port=$dbPort".$sslMode, $dbUser, $dbPwd, {RaiseError => 1, mysql_enable_utf8 => 1}) or die $DBI::errstr;
 
     return $dbh;
 

--- a/Api/Ocsinventory/Restapi/Computer/Get/ComputerId.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/ComputerId.pm
@@ -9,6 +9,7 @@ This function return a computer from his ID
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
 use Mojo::JSON qw(decode_json encode_json);
+use Encode qw(encode decode);
 
 sub get_computer {
 
@@ -23,7 +24,7 @@ sub get_computer {
         $json_return = Api::Ocsinventory::Restapi::ApiCommon::generate_item_software_json("computer", $computer->{ID}, $json_return, "");
     }
 
-    return encode_json($json_return);
+    return decode('UTF-8',encode_json($json_return));
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Computer/Get/Computers.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/Computers.pm
@@ -11,6 +11,7 @@ Params: start, limit
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
 use Mojo::JSON qw(decode_json encode_json);
+use Encode qw(encode decode);
 
 sub get_computers {
 
@@ -22,9 +23,10 @@ sub get_computers {
     foreach my $computer ( @$computers ) {
         $$json_return{"$computer->{ID}"}{"hardware"} = $computer;
         $json_return = Api::Ocsinventory::Restapi::ApiCommon::generate_item_datamap_json("computer", $computer->{ID}, $json_return, "");
+	$json_return = Api::Ocsinventory::Restapi::ApiCommon::generate_item_software_json("computer", $computer->{ID}, $json_return, "");
     }
 
-    return encode_json($json_return);
+    return decode('UTF-8',encode_json($json_return));
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
@@ -13,13 +13,13 @@ use Mojo::JSON qw(decode_json encode_json);
 sub get_ipdiscover_network{
 
     my ($network) = @_;
-    my $json_return;
+
     my $database = Api::Ocsinventory::Restapi::ApiCommon::api_database_connect();
     my $query = "SELECT * FROM `netmap` WHERE NETID = ? ";
     my @args = ($network);
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
-    return encode_json($json_return);
+    return encode_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Loader.pm
+++ b/Api/Ocsinventory/Restapi/Loader.pm
@@ -20,7 +20,7 @@ require Api::Ocsinventory::Restapi::Computer::Get::ComputersSearch; # Get list o
 ## IPDiscover section
 require Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover;
 require Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork;
-require Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverTag;
+#require Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverTag;
 
 ## SNMP section
 require Api::Ocsinventory::Restapi::Snmp::Get::SnmpId; # Get specific Snmp type informations
@@ -73,28 +73,28 @@ get '/v1/computers/search' => sub {
 get '/v1/ipdiscover' => sub {
         my $c = shift;
 
-        my $start = $c->param('start')||0;
-        my $limit = $c->param('limit')||0;
+        my $start = $c->param('start');
+        my $limit = $c->param('limit');
 
         $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover::get_ipdiscovers($start, $limit));
 };
 
-get '/v1/ipdiscover/:tag' => sub {
-        my $c = shift;
-        my $tag = $c->stash('tag');
+#get '/v1/ipdiscover/:tag' => sub {
+#        my $c = shift;
+#        my $tag = $c->stash('tag');
 
-        $c->render(json => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverTag::get_ipdiscover_tag($tag));
-};
+#        $c->render(json => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverTag::get_ipdiscover_tag($tag));
+#};
 
-get '/v1/ipdiscover/:network' => sub {
+get '/v1/ipdiscover/#network' => sub {
         my $c = shift;
 	# Debuggibg MH : Dump $c Mojo Object in /var/log/apache2/error.log
 #       warn "/v1/ipdiscover/:network : ".Dumper($c)."\n"; 
         my $network = $c->stash('network');
 	# QuickFix MH: donit know why a IPv4 10.20.30.40 is split as Mojo attrs: param=>10 format=20.30.40
-	$network .= ".".$c->stash('format');
+	#$network .= ".".$c->stash('format');
 	
-        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
+	$c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
 };
 
 get '/v1/snmps/typeList' => sub {


### PR DESCRIPTION
## Important notes 
OCSInventory-server : Communication server that manage the inventory

## General informations :
Operating system : CentOS 7

## Server informations :
PHP Version : 7.2.8
Web Server : Apache/2.4.6 (CentOS) OpenSSL/1.0.2k-fips mod_wsgi/3.4 Python/2.7.5 PHP/7.2.8 mod_perl/2.0.11 Perl/v5.16.3
Database Server : MariaDB Server version 10.4.12-MariaDB-log
Version OCSReports: 2.8 

## Status :
**READY**

## Description :
- Fix API bug with encoding special chars (problem with chinese characters)
- Fix API bug to list ipdiscover networks and ipdiscover assets
- Fix API bug to list computers (missing softwares in JSON)

Problem's description
I get my network list with the route http://myocsserver/ocsapi/v1/ipdiscover/ and my networks do not appear

When I tried to get network devices from a network range I have null result.
I use the route http://myocsserver/ocsapi/v1/ipdiscover/192.168.1.0

For the computer API Routes, this route didn't work: /ocsapi/v1/computers?start=0&limit=1

We had another problem with OS with chinese character (for example: "Microsoft Windows 10 企业版 2016 长期服务版")

So now this problems are fixed.
Thank you for your job! 
