### PR TITLE
Fix #220

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Ipdiscover.pm
@@ -149,6 +149,8 @@ sub _ipdiscover_main{
   my $current_context = shift;
 
   return if $current_context->{'LOCAL_FL'};
+
+  return unless (ref $current_context->{'PARAMS'}{'IPDISCOVER'} eq ref {}); # Not a HASH reference
   
   my $DeviceID = $current_context->{'DATABASE_ID'};
   my $dbh = $current_context->{'DBI_HANDLE'};


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system :

## Server informations :
Perl version :
Mysql / Mariadb / Percona version :  

## Status :
**READY**

## Description :
Fix perl error NOT A HASH REFERENCE on IpDiscover
