### PR TITLE
fix #124

### DIFF
--- a/Apache/Ocsinventory/Server/Inventory/Data.pm
+++ b/Apache/Ocsinventory/Server/Inventory/Data.pm
@@ -94,7 +94,10 @@ sub _init_map{
       $field_index++;      
     }
     # Build the "DBI->prepare" sql insert string 
-    $fields_string = join ',', ('HARDWARE_ID', @{$sectionsMeta->{$section}->{field_arrayref}});
+    for (@{$sectionsMeta->{$section}->{field_arrayref}}) {
+      s/^(.*)$/\`$1\`/;
+    }
+    $fields_string = join ',', ('`HARDWARE_ID`', @{$sectionsMeta->{$section}->{field_arrayref}});
     $sectionsMeta->{$section}->{sql_insert_string} = "INSERT INTO $section($fields_string) VALUES(";
     for(0..@{$sectionsMeta->{$section}->{field_arrayref}}){
       push @bind_num, '?';


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system : 20.04.1

## Server informations :
Perl version : 5.30
Mysql version :  8.0.22

## Status :
**READY**

## Description :
Add backquote to inventory insert.
#124
