### PR TITLE
orphaned lines on database

### DIFF
--- a/Apache/Ocsinventory/Map.pm
+++ b/Apache/Ocsinventory/Map.pm
@@ -367,6 +367,14 @@ our %DATA_MAP= (
    }
   },
 
+  software => {
+    mask => 0,
+    multi => 1,
+    auto => 1,
+    delOnReplace => 1,
+    fields =>  {}
+  },
+
   virtualmachines => {
     mask => 131072,
     multi => 1,

--- a/Apache/Ocsinventory/Server/Inventory.pm
+++ b/Apache/Ocsinventory/Server/Inventory.pm
@@ -142,10 +142,6 @@ sub _post_inventory{
   my $result = $Apache::Ocsinventory::CURRENT_CONTEXT{'XML_ENTRY'};
   my $dbh = $Apache::Ocsinventory::CURRENT_CONTEXT{'DBI_HANDLE'};
 
-  set_category();
-  &_insert_software();
-  set_asset_category();
-
   &_generate_ocs_file();
   &kill_session( \%Apache::Ocsinventory::CURRENT_CONTEXT );
   

--- a/Apache/Ocsinventory/Server/Inventory/Update.pm
+++ b/Apache/Ocsinventory/Server/Inventory/Update.pm
@@ -48,7 +48,11 @@ sub _update_inventory{
   my $section;
 
   set_category();
-  &_insert_software();
+
+  if(&_insert_software()) {
+    return 1;
+  }
+
   set_asset_category();  
   set_saas();
 


### PR DESCRIPTION
## Status :
**READY**

## Description :
Computer duplicate merge and some other cases is leaving orphaned lines on database.

When a computer duplicate is merged it doesn't delete software lines from the old computer,
leaving orphaned lines on table software `software.hardware_id` without a reference line on table hardware `hardware.id`.

Another case is when software insertion fails, it didn't rollback on error.

This pull-request fix this problems.