### PR TITLE
Fixing url to wiki page on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ git clone https://github.com/OCSInventory-NG/OCSInventory-ocsreports.git ocsrepo
 
 For more informations, please follow the OCS Inventory documentation :
 
-http://wiki.ocsinventory-ng.org/02.Basic-documentation/Setting-up-a-OCS-Inventory-Server/
+http://wiki.ocsinventory-ng.org/03.Basic-documentation/Setting-up-a-OCS-Inventory-Server/
 
 ## Contributing
 


### PR DESCRIPTION
Just a quick fix to the URL in the readme to point to right URL on the wiki