### PR TITLE
Api fix route ipdiscover

### DIFF
--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/Ipdiscover.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/Ipdiscover.pm
@@ -19,7 +19,7 @@ sub get_ipdiscovers{
     my $json_return;
     my $query = "SELECT NETID FROM `netmap` GROUP BY NETID";
 
-    my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, $start, $limit);
+    my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "");
 
     return encode_json($netmaps);
 }

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
@@ -13,10 +13,12 @@ use Mojo::JSON qw(decode_json encode_json);
 sub get_ipdiscover_network{
 
     my ($network) = @_;
-    my $json_return;
+
     my $database = Api::Ocsinventory::Restapi::ApiCommon::api_database_connect();
+
     my $query = "SELECT * FROM `netmap` WHERE NETID = ? ";
     my @args = ($network);
+    
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
     return encode_json($netmaps);

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
@@ -17,8 +17,9 @@ sub get_ipdiscover_network{
     my $database = Api::Ocsinventory::Restapi::ApiCommon::api_database_connect();
 
     my $query = "SELECT * FROM `netmap` WHERE NETID = ? ";
-    my @args = ($network);
     
+    my @args = ($network);
+
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
     return encode_json($netmaps);

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
@@ -19,7 +19,7 @@ sub get_ipdiscover_network{
     my @args = ($network);
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
-    return encode_json($json_return);
+    return encode_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
@@ -21,7 +21,7 @@ sub get_ipdiscover_tag{
 
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
-    return encode_json($json_return);
+    return encode_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
@@ -13,13 +13,13 @@ use Mojo::JSON qw(decode_json encode_json);
 sub get_ipdiscover_tag{
 
     my ($tag) = @_;
-    my $json_return;
+
     my $database = Api::Ocsinventory::Restapi::ApiCommon::api_database_connect();
 
-    my $json_return = $database->selectall_arrayref(
-        "SELECT * from netmap WHERE TAG = '$tag'",
-        { Slice => {} }
-    );
+    my $query = "SELECT * from `netmap` WHERE TAG = ?";
+    my @args = ($tag);
+
+    my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
     return encode_json($json_return);
 }

--- a/Api/Ocsinventory/Restapi/Loader.pm
+++ b/Api/Ocsinventory/Restapi/Loader.pm
@@ -95,7 +95,7 @@ get '/v1/ipdiscover' => sub {
         my $start = $c->param('start')||0;
         my $limit = $c->param('limit')||0;
 
-        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover::get_ipdiscovers($start, $limit));
+        $c->render(format => 'json', text => Api::Ocsinventory::Restapi::Ipdiscover::Get::Ipdiscover::get_ipdiscovers($start, $limit));
 };
 
 get '/v1/ipdiscover/tag/:tag' => sub {
@@ -110,7 +110,7 @@ get '/v1/ipdiscover/network/#network' => sub {
 
         my $network = $c->stash('network');
         	
-        $c->render(format => 'json', text  => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
+        $c->render(format => 'json', text => Api::Ocsinventory::Restapi::Ipdiscover::Get::IpdiscoverNetwork::get_ipdiscover_network($network));
 };
 
 get '/v1/snmps/typeList' => sub {


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system :

## Server informations :
Perl version :
Mysql / Mariadb / Percona version :  

## Status :
**READY/IN DEVELOPMENT/HOLD**

## Description :
Retrieve Ipdiscover to validate the route of Netwok and Tag. Also fix the bug about the render's null in the REST Api.
