### PR TITLE
Api output encoding

### DIFF
--- a/Api/Ocsinventory/Restapi/Computer/Get/ComputerId.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/ComputerId.pm
@@ -8,7 +8,7 @@ This function return a computer from his ID
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_computer {
 
@@ -23,7 +23,7 @@ sub get_computer {
         $json_return = Api::Ocsinventory::Restapi::ApiCommon::generate_item_software_json("computer", $computer->{ID}, $json_return, "");
     }
 
-    return encode_json($json_return);
+    return to_json($json_return);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Computer/Get/ComputerIdField.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/ComputerIdField.pm
@@ -8,7 +8,7 @@ This function return a computer field from his ID and field
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_computer_field {
 
@@ -26,7 +26,7 @@ sub get_computer_field {
         }
     }
 
-    return encode_json($json_return);
+    return to_json($json_return);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Computer/Get/Computers.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/Computers.pm
@@ -10,7 +10,7 @@ Params: start, limit
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_computers {
 
@@ -24,7 +24,7 @@ sub get_computers {
         $json_return = Api::Ocsinventory::Restapi::ApiCommon::generate_item_datamap_json("computer", $computer->{ID}, $json_return, "");
     }
 
-    return encode_json($json_return);
+    return to_json($json_return);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Computer/Get/ComputersListId.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/ComputersListId.pm
@@ -10,7 +10,7 @@ Params: start, limit
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_computers_id {
 
@@ -21,7 +21,7 @@ sub get_computers_id {
         { Slice => {} }
     );
 
-    return encode_json($computers);
+    return to_json($computers);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Computer/Get/ComputersSearch.pm
+++ b/Api/Ocsinventory/Restapi/Computer/Get/ComputersSearch.pm
@@ -10,7 +10,7 @@ Params: table.fieldname = value
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_computers_search {
 
@@ -20,7 +20,7 @@ sub get_computers_search {
 
     my $query = Api::Ocsinventory::Restapi::ApiCommon::format_query_for_computer_search($url_params);
 
-    return encode_json($query);
+    return to_json($query);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Cve/Get/CveComputer.pm
+++ b/Api/Ocsinventory/Restapi/Cve/Get/CveComputer.pm
@@ -2,7 +2,7 @@ package Api::Ocsinventory::Restapi::Cve::Get::CveComputer;
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_cve_computer {
 
@@ -24,7 +24,7 @@ sub get_cve_computer {
 
     my $query = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($sql, $start, $limit);
 
-    return encode_json($query);
+    return to_json($query);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Cve/Get/CveCvss.pm
+++ b/Api/Ocsinventory/Restapi/Cve/Get/CveCvss.pm
@@ -2,7 +2,7 @@ package Api::Ocsinventory::Restapi::Cve::Get::CveCvss;
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_cve_cvss {
 
@@ -24,7 +24,7 @@ sub get_cve_cvss {
 
     my $query = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($sql, $start, $limit);
 
-    return encode_json($query);
+    return to_json($query);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Cve/Get/CveSoftware.pm
+++ b/Api/Ocsinventory/Restapi/Cve/Get/CveSoftware.pm
@@ -2,7 +2,7 @@ package Api::Ocsinventory::Restapi::Cve::Get::CveSoftware;
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_cve_software {
 
@@ -24,7 +24,7 @@ sub get_cve_software {
 
     my $query = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($sql, $start, $limit);
 
-    return encode_json($query);
+    return to_json($query);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/Ipdiscover.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/Ipdiscover.pm
@@ -10,7 +10,7 @@ Params: start, limit
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_ipdiscovers{
 
@@ -21,7 +21,7 @@ sub get_ipdiscovers{
 
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "");
 
-    return encode_json($netmaps);
+    return to_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverNetwork.pm
@@ -8,7 +8,7 @@ This function return a IPDiscover object from network
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_ipdiscover_network{
 
@@ -22,7 +22,7 @@ sub get_ipdiscover_network{
 
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
-    return encode_json($netmaps);
+    return to_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
+++ b/Api/Ocsinventory/Restapi/Ipdiscover/Get/IpdiscoverTag.pm
@@ -8,7 +8,7 @@ This function return a IPDiscover object from tag
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_ipdiscover_tag{
 
@@ -21,7 +21,7 @@ sub get_ipdiscover_tag{
 
     my $netmaps = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, "", "", @args);
 
-    return encode_json($netmaps);
+    return to_json($netmaps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Snmp/Get/SnmpId.pm
+++ b/Api/Ocsinventory/Restapi/Snmp/Get/SnmpId.pm
@@ -8,7 +8,7 @@ This function return a snmp from his ID
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_snmp_id {
 
@@ -19,7 +19,7 @@ sub get_snmp_id {
 
     my $json_return = Api::Ocsinventory::Restapi::ApiCommon::execute_custom_request($query, $start, $limit);
 
-    return encode_json($json_return);
+    return to_json($json_return);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Snmp/Get/SnmpIdField.pm
+++ b/Api/Ocsinventory/Restapi/Snmp/Get/SnmpIdField.pm
@@ -8,7 +8,7 @@ This function return a snmp field from his ID and field
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_snmp_field {
 
@@ -21,7 +21,7 @@ sub get_snmp_field {
         { Slice => {} }
     );
 
-    return encode_json($snmps);
+    return to_json($snmps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Snmp/Get/SnmpListId.pm
+++ b/Api/Ocsinventory/Restapi/Snmp/Get/SnmpListId.pm
@@ -10,7 +10,7 @@ Params: start, limit
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_snmps_id {
 
@@ -21,7 +21,7 @@ sub get_snmps_id {
         { Slice => {} }
     );
 
-    return encode_json($snmps);
+    return to_json($snmps);
 }
 
 1;

--- a/Api/Ocsinventory/Restapi/Software/Get/Softwares.pm
+++ b/Api/Ocsinventory/Restapi/Software/Get/Softwares.pm
@@ -10,7 +10,7 @@ Params: start, limit
 
 # Common sub for api
 use Api::Ocsinventory::Restapi::ApiCommon;
-use Mojo::JSON qw(decode_json encode_json);
+use Mojo::JSON qw(to_json);
 
 sub get_softwares {
 
@@ -19,7 +19,7 @@ sub get_softwares {
 
     my $softwares = Api::Ocsinventory::Restapi::ApiCommon::generate_item_all_softwares_json($limit, $start, $soft);
 
-    return encode_json($softwares);
+    return to_json($softwares);
 }
 
 1;


### PR DESCRIPTION
## Status :
**READY**

## Description :
change api output methods from encode_json to to_json to avoid re encoding the output (see https://github.com/OCSInventory-NG/OCSInventory-ocsreports/issues/1171)
