### PR TITLE
Avoid warnings in SoftwareCategory.pm

### DIFF
--- a/Apache/Ocsinventory/Interface/SoftwareCategory.pm
+++ b/Apache/Ocsinventory/Interface/SoftwareCategory.pm
@@ -142,7 +142,7 @@ sub set_category{
 
             $regex = regex($regex);
 
-            if(( $os eq 'ALL' ) || ( $Apache::Ocsinventory::CURRENT_CONTEXT{'USER_AGENT'} =~ m/$os/ )){
+            if(defined($os) && ($os eq 'ALL' || $Apache::Ocsinventory::CURRENT_CONTEXT{'USER_AGENT'} =~ m/$os/)){
               if (defined $softName) {
                 if ($softName =~ $regex) {
                   if( ( defined $sign ) && ( $sign ne '' )){


### PR DESCRIPTION
## Status :
**READY**

## Description :
Fix warnings for "use of uninitialized value $os" in SoftwareCategory.pm appearing in server's logs when inventory is received
