### PR TITLE
Fix Api Conf Bug

### DIFF
--- a/Api/Ocsinventory/Restapi/ApiCommon.pm
+++ b/Api/Ocsinventory/Restapi/ApiCommon.pm
@@ -31,7 +31,7 @@ sub api_database_connect{
 
     # Retrieve env var
     $dbHost = $ENV{'OCS_DB_HOST'};
-    $dbName = $ENV{'OCS_DB_NAME'}||'ocsweb';
+    $dbName = $ENV{'OCS_DB_LOCAL'}||$ENV{'OCS_DB_NAME'}||'ocsweb';
     $dbPort = $ENV{'OCS_DB_PORT'}||'3306';
     $dbUser = $ENV{'OCS_DB_USER'};
     $dbPwd  = $ENV{'OCS_DB_PWD'};

--- a/etc/ocsinventory/ocsinventory-restapi.conf
+++ b/etc/ocsinventory/ocsinventory-restapi.conf
@@ -7,6 +7,7 @@ PerlOptions +Parent
   $ENV{OCS_DB_HOST} = 'localhost';
   $ENV{OCS_DB_PORT} = '3306';
   $ENV{OCS_DB_LOCAL} = 'ocsweb';
+  $ENV{OCS_DB_NAME} = 'ocsweb';
   $ENV{OCS_DB_USER} = 'ocs';
   $ENV{OCS_DB_PWD} = 'ocs';
   $ENV{OCS_DB_SSL_ENABLED} = 0;


### PR DESCRIPTION
There is no `OCS_DB_LOCAL` env in Api DB connection.
Changing Api DB connection to try multiples connections values like [OCSInventory-NG/OCSInventory-Server](https://github.com/OCSInventory-NG/OCSInventory-Server/blob/a5ee103f2f3d796dd5dd2a7685405861170b6e70/Apache/Ocsinventory/Server/System.pm#L159)

## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system :

## Server informations :
Perl version :
Mysql / Mariadb / Percona version :  

## Status :
**READY/IN DEVELOPMENT/HOLD**

## Description :
A few sentences describing the overall goals of the pull request's commits.
