### PR TITLE
fix DB perfomance issue

### DIFF
--- a/Apache/Ocsinventory/Server/Duplicate.pm
+++ b/Apache/Ocsinventory/Server/Duplicate.pm
@@ -176,10 +176,10 @@ sub _duplicate_detect{
 
   # ...and one MAC of this machine
   for(@{$result->{CONTENT}->{NETWORKS}}){
-    $request = $dbh->prepare('SELECT HARDWARE_ID,DESCRIPTION,MACADDR FROM networks WHERE MACADDR=? AND HARDWARE_ID<>?');
-    $request->execute($_->{MACADDR}, $DeviceID);
-    while($row = $request->fetchrow_hashref()){
-      if(!&_already_in_array($row->{'MACADDR'}, \@bad_mac)){
+    if(!&_already_in_array($row->{'MACADDR'}, \@bad_mac)){
+      $request = $dbh->prepare('SELECT HARDWARE_ID,DESCRIPTION,MACADDR FROM networks WHERE MACADDR=? AND HARDWARE_ID<>?');
+      $request->execute($_->{MACADDR}, $DeviceID);
+      while($row = $request->fetchrow_hashref()){
         $exist->{$row->{'HARDWARE_ID'}}->{'MACADDRESS'}++;
       }
     }


### PR DESCRIPTION
## Important notes 
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations :
Operating system : CentOS 7

## Server informations :
Perl version : v5.16.3
Mysql / Mariadb / Percona version :  10.2.44-MariaDB

## Status :
**READY**

## Description :
In a bigger environment ~40k clients, we have faced a database performance issue, caused by the query:
SELECT HARDWARE_ID,DESCRIPTION,MACADDR FROM networks WHERE MACADDR='00:00:00:00:00:00' AND HARDWARE_ID<>123123

This caused a heavy network load between the Frontend and DB server, because every client has 5 virtual network cards with mac addr 00:00:00:00:00:00. 

I moved the condition if the mac address exists in blacklist, before the query will be executed.
In your  current branch, the condition if the mac addr is blacklisted is after the query... that hurts the database :)
