### PR TITLE
fixed heavy DB load by prevent macaddr query

### DIFF
--- a/Apache/Ocsinventory/Server/Duplicate.pm
+++ b/Apache/Ocsinventory/Server/Duplicate.pm
@@ -176,10 +176,10 @@ sub _duplicate_detect{
 
   # ...and one MAC of this machine
   for(@{$result->{CONTENT}->{NETWORKS}}){
-    $request = $dbh->prepare('SELECT HARDWARE_ID,DESCRIPTION,MACADDR FROM networks WHERE MACADDR=? AND HARDWARE_ID<>?');
-    $request->execute($_->{MACADDR}, $DeviceID);
-    while($row = $request->fetchrow_hashref()){
-      if(!&_already_in_array($row->{'MACADDR'}, \@bad_mac)){
+    if(!&_already_in_array($_->{'MACADDR'}, \@bad_mac)){
+      $request = $dbh->prepare('SELECT HARDWARE_ID,DESCRIPTION,MACADDR FROM networks WHERE MACADDR=? AND HARDWARE_ID<>?');
+      $request->execute($_->{MACADDR}, $DeviceID);
+      while($row = $request->fetchrow_hashref()){
         $exist->{$row->{'HARDWARE_ID'}}->{'MACADDRESS'}++;
       }
     }


### PR DESCRIPTION
## Status :
READY

## Description :
I fixed an issue you'll face if you have a huge amount of clients with virtual network cards and its macaddr '00:00:00:00:00:00'.

How the behaviour is before this commit:
--> 40k clients with 5 virtual nic adapter
--> every time when sub _duplicate_detect was called this sub queried the database 5 times "give me all networks with mac addresses 00:00:00:00:00:00" wich doesn't have my hardware_id
--> this causes the database to return around 200k entries, five times...
--> .. so the frontend has to loop 1M entries and calls the funtion already_in_array 1M times

How the behaviour is after my commit:
--> 40k clients with 5 virtual nic adapter
--> every time when sub _duplicate_detect is called this sub queries the database 0 times "give me all networks with mac addresses 00:00:00:00:00:00" wich doesn't have my hardware_id
--> this causes the database to return exactly 0 entries, zero times...
--> .. so the frontend has to loop zero entries and calls the funtion already_in_array zero times

So the only thing I changed, was to check the blacklist before the database is queried.
In your logic the sub first queries the database and checking each result of an blicklisted macaddr if its on the blacklist.


--> Sorry the last pull request I created had a bug o((⊙﹏⊙))o.

greetings eldo
