### PR TITLE
Fix group teledeploy force

### DIFF
--- a/Apache/Ocsinventory/Server/Capacities/Download.pm
+++ b/Apache/Ocsinventory/Server/Capacities/Download.pm
@@ -196,7 +196,7 @@ sub download_prolog_resp{
         &get_postcmd_packages($dbh, $_, \@postcmd_packages);
 
         #We get packages marked as forced affeted to the group
-        &get_forced_packages($dbh, $hardware_id, \@forced_packages);
+        &get_forced_packages($dbh, $_, \@forced_packages);
 
         while( $pack_row = $pack_req->fetchrow_hashref ){
           my $fileid = $pack_row->{'FILEID'};


### PR DESCRIPTION
## Important notes
Please, don't mistake OCSInventory-server with OCSInventory-ocsreports :
* OCSInventory-server : Communication server that manage the inventory
* OCSInventory-ocsreports : Web interface of OCS Inventory

## General informations
Operating system :

## Server informations
Perl version :
Mysql / Mariadb / Percona version :  

## Status
**READY/IN DEVELOPMENT/HOLD**

## Description
A few sentences describing the overall goals of the pull request's commits.
