### PR TITLE
Commit for update statement of agent inventories

### DIFF
--- a/Apache/Ocsinventory/Server/Inventory/Data.pm
+++ b/Apache/Ocsinventory/Server/Inventory/Data.pm
@@ -93,25 +93,36 @@ sub _init_map{
  
       $field_index++;      
     }
-    # Build the "DBI->prepare" sql insert string 
-    for (@{$sectionsMeta->{$section}->{field_arrayref}}) {
-      s/^(.*)$/\`$1\`/;
-    }
-    $fields_string = join ',', ('`HARDWARE_ID`', @{$sectionsMeta->{$section}->{field_arrayref}});
-    $sectionsMeta->{$section}->{sql_insert_string} = "INSERT INTO $section($fields_string) VALUES(";
-    for(0..@{$sectionsMeta->{$section}->{field_arrayref}}){
-      push @bind_num, '?';
-    }
+    # $fields_string = join ',', ('`HARDWARE_ID`', @{$sectionsMeta->{$section}->{field_arrayref}});
+    # $sectionsMeta->{$section}->{sql_insert_string} = "INSERT INTO $section($fields_string) VALUES(";
+    # for(0..@{$sectionsMeta->{$section}->{field_arrayref}}){
+    #   push @bind_num, '?';
+    # }
     
-    $sectionsMeta->{$section}->{sql_insert_string}.= (join ',', @bind_num).')';
-    @bind_num = ();
+    # $sectionsMeta->{$section}->{sql_insert_string}.= (join ',', @bind_num).')';
+    # @bind_num = ();
     # Build the "DBI->prepare" sql select string 
+  for my $section (@$sectionsList) {
+      my $fields_string = join ',', ('HARDWARE_ID', @{$sectionsMeta->{$section}->{field_arrayref}});
+      
+      # Build the "DBI->prepare" sql insert string
+      $sectionsMeta->{$section}->{sql_insert_string} = "
+          MERGE INTO $section USING dual ON ($section.HARDWARE_ID = ? AND $section.ID = ?)
+          WHEN MATCHED THEN
+              UPDATE SET $fields_string = VALUES($fields_string)
+          WHEN NOT MATCHED THEN
+              INSERT ($fields_string) VALUES (?)
+          WHEN NOT MATCHED BY SOURCE THEN
+              DELETE;
+      ";
+  }
     $sectionsMeta->{$section}->{sql_select_string} = "SELECT ID,$fields_string FROM $section 
       WHERE HARDWARE_ID=? ORDER BY ".$DATA_MAP{$section}->{sortBy};
     # Build the "DBI->prepare" sql deletion string 
-    $sectionsMeta->{$section}->{sql_delete_string} = "DELETE FROM $section WHERE HARDWARE_ID=? AND ID=?";
+#    $sectionsMeta->{$section}->{sql_delete_string} = "DELETE FROM $section WHERE HARDWARE_ID=? AND ID=?";
     # to avoid many "keys"
-    push @$sectionsList, $section;
+#    push @$sectionsList, $section;
+
   }
 
   #Special treatment for hardware section

--- a/Apache/Ocsinventory/Server/Inventory/Update.pm
+++ b/Apache/Ocsinventory/Server/Inventory/Update.pm
@@ -146,17 +146,17 @@ sub _update_inventory_section{
         }
       }
     }
-    # Now we have to delete from DB elements that still remain in fromDb
-    for (@fromDb){
-      next if !defined (${$_}[0]);
-      $del++;
-      $dbh->do( $sectionMeta->{sql_delete_string}, {}, $deviceId, ${$_}[0]) or return 1;
-      my @ldb = @$_;
-      @ldb = @ldb[ 2..$#ldb ];
-      if( $ENV{OCS_OPT_INVENTORY_CACHE_ENABLED} && $sectionMeta->{cache} && !$ENV{OCS_OPT_INVENTORY_CACHE_KEEP}){
-        &_cache( 'del', $section, $sectionMeta, \@ldb );
-      }
-    }
+    # # Now we have to delete from DB elements that still remain in fromDb
+    # for (@fromDb){
+    #   next if !defined (${$_}[0]);
+    #   $del++;
+    #   $dbh->do( $sectionMeta->{sql_delete_string}, {}, $deviceId, ${$_}[0]) or return 1;
+    #   my @ldb = @$_;
+    #   @ldb = @ldb[ 2..$#ldb ];
+    #   if( $ENV{OCS_OPT_INVENTORY_CACHE_ENABLED} && $sectionMeta->{cache} && !$ENV{OCS_OPT_INVENTORY_CACHE_KEEP}){
+    #     &_cache( 'del', $section, $sectionMeta, \@ldb );
+    #   }
+    # }
     if( $new||$del ){
       &_log( 113, 'write_diff', "ch:$section(+$new-$del)") if $ENV{'OCS_OPT_LOGLEVEL'};
     }


### PR DESCRIPTION
The code has sto be adapted but here is the fix I did in order not to have a systematic insert and delete during agent update database fields when there are changes detected during inventory.

The code performs an update, then, if the entry does not exist in the database it performs an insert and, at the end, if the data is not present in source anymore it performs a delete.

Please note that the code has to be adapted because we do not use the WRITE_DIFF option anymore in our fix